### PR TITLE
Fix reveal answer on space but

### DIFF
--- a/src/components/DeckStats.vue
+++ b/src/components/DeckStats.vue
@@ -269,12 +269,6 @@
     gap: 1em;
     flex-grow: 1;
     padding-top: 1em;
-    font-size: 1.5em;
-  }
-  @media (min-width: 768px) {
-    #cards {
-      font-size: 2rem;
-    }
   }
 
   .card {
@@ -286,6 +280,7 @@
     border: none;
     box-shadow: 0 0 3px 0px hsl(0, 0%, 50%);
     height: 100%;
+    font-size: 1.3em;
   }
   .stamp {
     position: absolute;

--- a/src/components/FlashCard.vue
+++ b/src/components/FlashCard.vue
@@ -131,7 +131,7 @@
 <template>
   <h1>{{ currentDeck.title }}</h1>
   <div class="flashcard">
-    <router-link :to="`${cardNr}`">
+    <router-link :to="`${cardNr}`" tabindex="-1">
       <button class="arrow-button left-arrow" @click="goPrevious(cardNr)">
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -157,7 +157,7 @@
     </div>
     <span id="count">{{ cardIndex }}/{{ cardAmount }}</span>
 
-    <router-link :to="`${cardNr}`">
+    <router-link :to="`${cardNr}`" tabindex="-1">
       <button class="arrow-button" @click="goNext">
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/src/components/FlashCard.vue
+++ b/src/components/FlashCard.vue
@@ -102,6 +102,10 @@
           cardNr: cardNr.value
         }
       });
+      // Removes focus from arrow, so that when user press space it wont flip to next card
+      document.querySelectorAll(".arrow-button").forEach((button) => {
+        button.blur();
+      });
     }
   }
 
@@ -116,6 +120,10 @@
           deckId,
           cardNr: cardNr.value
         }
+      });
+      // Removes focus from arrow, so that when user press space it wont flip to next card
+      document.querySelectorAll(".arrow-button").forEach((button) => {
+        button.blur();
       });
     }
   }
@@ -191,20 +199,21 @@
     justify-content: center;
     align-items: center;
     text-align: center;
+    font-size: 1em;
   }
   #count {
     position: absolute;
     top: 15px;
     right: 20px;
     color: var(--grey);
-    font-size: 1.3rem;
+    font-size: 1.1em;
   }
 
   .arrow-button {
     background-color: var(--light);
     color: var(--grey);
     border: none;
-    padding: 1.5em;
+    padding: 0.5em;
     cursor: pointer;
     transition: background-color 0.3s ease;
     font-size: 24px;
@@ -217,6 +226,9 @@
     #front,
     #back {
       padding: 0 4rem;
+    }
+    .flashcard-content {
+      font-size: 1.3em;
     }
   }
 </style>

--- a/src/views/CardView.vue
+++ b/src/views/CardView.vue
@@ -68,7 +68,7 @@
     height: 90vh;
     padding-top: 2em;
     width: clamp(9em, 95%, 43em);
-    font: 1.5em Arial, sans-serif;
+    font: Arial, sans-serif;
   }
   .buttons-container {
     display: flex;


### PR DESCRIPTION
Bug desc
When pressed arrow and then press space to reveal answer, arrow will be selected and quickly reveal answer and then switch to next question. This is not wanted, we want to stay at the same card when spaced pressed. This is fixed now